### PR TITLE
Update IC2 external energy manager implementation, make TR items into electric items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ dependencies {
 	}
 
 
-	compile "mcp.mobius.waila:Hwyla:+"
+	compile "mcp.mobius.waila:Hwyla:1.8+"
 	compile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.12.323"
 	compile name: 'buildcraft', version: '7.99.19', ext: 'jar'
 		

--- a/src/main/java/techreborn/compatmod/ic2/RebronCoreIC2.java
+++ b/src/main/java/techreborn/compatmod/ic2/RebronCoreIC2.java
@@ -1,11 +1,15 @@
 package techreborn.compatmod.ic2;
 
+import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergyTile;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import reborncore.api.power.ExternalPowerHandler;
 import reborncore.api.power.ExternalPowerManager;
 import reborncore.common.powerSystem.TilePowerAcceptor;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
 import reborncore.common.registration.RebornRegistry;
 import reborncore.common.registration.impl.ConfigRegistry;
 import techreborn.lib.ModInfo;
@@ -16,6 +20,10 @@ public class RebronCoreIC2 implements ExternalPowerManager {
 	@ConfigRegistry(config = "ic2", comment = "Should ic2 power support be enabled? (Requires restart)")
 	public static boolean ic2Power = true;
 
+	public RebronCoreIC2() {
+
+	}
+
 	@Override
 	public ExternalPowerHandler createPowerHandler(TilePowerAcceptor acceptor) {
 		if(!ic2Power){
@@ -25,11 +33,11 @@ public class RebronCoreIC2 implements ExternalPowerManager {
 	}
 
 	@Override
-	public boolean isPoweredTile(TileEntity tileEntity) {
+	public boolean isPoweredTile(TileEntity tileEntity, EnumFacing facing) {
 		if(!ic2Power){
 			return false;
 		}
-		return tileEntity instanceof IEnergyTile;
+		return tileEntity instanceof IEnergyTile || EnergyNet.instance.getTile(tileEntity.getWorld(), tileEntity.getPos()) != null;
 	}
 
 	@Override
@@ -54,5 +62,15 @@ public class RebronCoreIC2 implements ExternalPowerManager {
 			return;
 		}
 		IC2ItemCharger.chargeIc2Item(tilePowerAcceptor, stack);
+	}
+
+	@Override
+	public void chargeItem(ForgePowerItemManager powerAcceptor, ItemStack stack) {
+		IC2ItemCharger.chargeIc2Item(powerAcceptor, stack);
+	}
+
+	@Override
+	public void requestEnergyFromArmor(ForgePowerItemManager powerAcceptor, EntityLivingBase entity) {
+		IC2ItemCharger.requestEnergyFromIc2Armor(powerAcceptor, entity);
 	}
 }

--- a/src/main/java/techreborn/compatmod/ic2/RebronCoreIC2.java
+++ b/src/main/java/techreborn/compatmod/ic2/RebronCoreIC2.java
@@ -2,6 +2,7 @@ package techreborn.compatmod.ic2;
 
 import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergyTile;
+import ic2.api.item.ElectricItem;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -21,7 +22,9 @@ public class RebronCoreIC2 implements ExternalPowerManager {
 	public static boolean ic2Power = true;
 
 	public RebronCoreIC2() {
-
+		if(ic2Power) {
+			ElectricItem.registerBackupManager(new TRBackupElectricItemManager(this));
+		}
 	}
 
 	@Override

--- a/src/main/java/techreborn/compatmod/ic2/TRBackupElectricItemManager.java
+++ b/src/main/java/techreborn/compatmod/ic2/TRBackupElectricItemManager.java
@@ -1,0 +1,150 @@
+package techreborn.compatmod.ic2;
+
+import ic2.api.item.IBackupElectricItemManager;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import reborncore.api.power.IEnergyItemInfo;
+import reborncore.common.RebornCoreConfig;
+import reborncore.common.powerSystem.forge.ForgePowerItemManager;
+
+public class TRBackupElectricItemManager implements IBackupElectricItemManager {
+	private RebronCoreIC2 externalPowerManager;
+
+	TRBackupElectricItemManager(RebronCoreIC2 externalPowerManager) {
+		this.externalPowerManager = externalPowerManager;
+	}
+
+	@Override
+	public boolean handles(ItemStack stack) {
+		return !stack.isEmpty() && stack.getItem() instanceof IEnergyItemInfo;
+	}
+
+	@Override
+	public double charge(ItemStack stack, double amount, int tier, boolean ignoreTransferLimit, boolean simulate) {
+		if(!handles(stack)) {
+			return 0.0;
+		}
+
+		ForgePowerItemManager item = new ForgePowerItemManager(stack);
+		IEnergyItemInfo info = (IEnergyItemInfo)stack.getItem();
+
+		if (!item.canReceive()) {
+			return 0.0;
+		}
+
+		int maxReceive = (int)(amount * RebornCoreConfig.euPerFU);
+		if(!ignoreTransferLimit) {
+			maxReceive = Math.min(maxReceive, (int)info.getMaxTransfer(stack));
+		}
+
+		int energyReceived = Math.min(item.getMaxEnergyStored() - item.getEnergyStored(), maxReceive);
+
+		if (!simulate) {
+			item.setEnergy(item.getEnergyStored() + energyReceived);
+		}
+
+		return energyReceived / RebornCoreConfig.euPerFU;
+	}
+
+	@Override
+	public double discharge(ItemStack stack, double amount, int tier, boolean ignoreTransferLimit, boolean externally, boolean simulate) {
+		if(!handles(stack)) {
+			return 0.0;
+		}
+
+		ForgePowerItemManager item = new ForgePowerItemManager(stack);
+		IEnergyItemInfo info = (IEnergyItemInfo)stack.getItem();
+
+		if (!item.canExtract()) {
+			return 0.0;
+		}
+
+		int maxExtract = (int)(amount * RebornCoreConfig.euPerFU);
+		if(!ignoreTransferLimit) {
+			maxExtract = Math.min(maxExtract, (int)info.getMaxTransfer(stack));
+		}
+
+		int energyExtracted = Math.min(item.getEnergyStored(), maxExtract);
+
+		if (!simulate) {
+			item.setEnergy(item.getEnergyStored() - energyExtracted);
+		}
+
+		return energyExtracted / RebornCoreConfig.euPerFU;
+	}
+
+	@Override
+	public double getCharge(ItemStack stack) {
+		if(!handles(stack)) {
+			return 0.0;
+		}
+
+		ForgePowerItemManager item = new ForgePowerItemManager(stack);
+
+		if(!item.canExtract()) {
+			return 0.0;
+		}
+
+		return item.getEnergyStored() / RebornCoreConfig.euPerFU;
+	}
+
+	@Override
+	public double getMaxCharge(ItemStack stack) {
+		if(!handles(stack)) {
+			return 0.0;
+		}
+
+		ForgePowerItemManager item = new ForgePowerItemManager(stack);
+
+		return item.getMaxEnergyStored() / RebornCoreConfig.euPerFU;
+	}
+
+	@Override
+	public boolean canUse(ItemStack stack, double amount) {
+		return getCharge(stack) >= amount;
+	}
+
+	@Override
+	public boolean use(ItemStack stack, double amount, EntityLivingBase entity) {
+		if(!handles(stack)) {
+			return false;
+		}
+
+		chargeFromArmor(stack, entity);
+		double maxTransfer = discharge(stack, amount, Integer.MAX_VALUE, true, false, true);
+
+		if((int)maxTransfer == (int)amount) {
+			discharge(stack, amount, Integer.MAX_VALUE, true, false, false);
+			chargeFromArmor(stack, entity);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public void chargeFromArmor(ItemStack stack, EntityLivingBase entity) {
+		if(!handles(stack)) {
+			return;
+		}
+
+		ForgePowerItemManager item = new ForgePowerItemManager(stack);
+
+		externalPowerManager.requestEnergyFromArmor(item, entity);
+	}
+
+	@Override
+	public String getToolTip(ItemStack stack) {
+		// Return null to prevent IC2 from drawing a tooltip since we already draw one
+
+		return null;
+	}
+
+	@Override
+	public int getTier(ItemStack stack) {
+		// TechReborn does not have a concept of electric item tiers.
+
+		return 4;
+	}
+}


### PR DESCRIPTION
This PR adds the new APIs from ExternalEnergyManager (chargeItem and requestEnergyFromArmor) to the IC2E implementation. Additionally, it registers an IBackupElectricItemManager so that TR items can be charged and discharged by IC2 blocks and items.

Also, I had to pin the WAILA dependency since it was trying to download the 1.14 revisions, so I had to fix it before I could begin work.