### PR TITLE
Work around IC2C getOfferedEnergy implementation bug

### DIFF
--- a/src/main/java/techreborn/compatmod/ic2/power/IC2EnergyDelegate.java
+++ b/src/main/java/techreborn/compatmod/ic2/power/IC2EnergyDelegate.java
@@ -16,9 +16,11 @@ public class IC2EnergyDelegate implements IEnergyTile, IEnergySink, IEnergySourc
 
 	TilePowerAcceptor powerAcceptor;
 	protected boolean addedToEnet;
+	boolean useIc2cWorkaround;
 
-	public IC2EnergyDelegate(TilePowerAcceptor powerAcceptor) {
+	public IC2EnergyDelegate(TilePowerAcceptor powerAcceptor, boolean useIc2cWorkaround) {
 		this.powerAcceptor = powerAcceptor;
+		this.useIc2cWorkaround = useIc2cWorkaround;
 	}
 
 	@Override
@@ -47,7 +49,15 @@ public class IC2EnergyDelegate implements IEnergyTile, IEnergySink, IEnergySourc
 	// IEnergySource
 	@Override
 	public double getOfferedEnergy() {
-		return Math.min(powerAcceptor.getEnergy(), powerAcceptor.getMaxOutput() * powerAcceptor.maxPacketsPerTick);
+		double maxOffered = powerAcceptor.getMaxOutput() * powerAcceptor.maxPacketsPerTick;
+
+		if(useIc2cWorkaround) {
+			// IC2 Classic thinks that getOfferedEnergy refers to each packet...
+			// This prevents explosions on transformers.
+			maxOffered = powerAcceptor.getMaxOutput();
+		}
+
+		return Math.min(powerAcceptor.getEnergy(), maxOffered);
 	}
 
 	@Override

--- a/src/main/java/techreborn/compatmod/ic2/power/IC2PowerManager.java
+++ b/src/main/java/techreborn/compatmod/ic2/power/IC2PowerManager.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Loader;
 import reborncore.api.power.ExternalPowerHandler;
 import reborncore.api.power.ExternalPowerManager;
 import reborncore.common.powerSystem.TilePowerAcceptor;
@@ -21,9 +22,12 @@ public class IC2PowerManager implements ExternalPowerManager {
 	@ConfigRegistry(config = "ic2", comment = "Should ic2 power support be enabled? (Requires restart)")
 	public static boolean ic2Power = true;
 
+	private boolean useIc2cWorkaround;
+
 	public IC2PowerManager() {
 		if(ic2Power) {
 			ElectricItem.registerBackupManager(new TRBackupElectricItemManager(this));
+			useIc2cWorkaround = Loader.isModLoaded("ic2-classic-spmod");
 		}
 	}
 
@@ -32,7 +36,7 @@ public class IC2PowerManager implements ExternalPowerManager {
 		if(!ic2Power){
 			return null;
 		}
-		return new IC2EnergyDelegate(acceptor);
+		return new IC2EnergyDelegate(acceptor, useIc2cWorkaround);
 	}
 
 	@Override


### PR DESCRIPTION
This works around https://github.com/TinyModularThings/IC2Classic/issues/297. Effectively, there are 2 separate interpretations of the `getOfferedEnergy` API, and as it happens IC2E and IC2C choose different ones. This should be the final PR of the multipacket transformer saga.